### PR TITLE
the Agent API no longer requires a client side certificate.

### DIFF
--- a/src/SymphonyOSS.RestApiClient/Factories/AgentApiFactory.cs
+++ b/src/SymphonyOSS.RestApiClient/Factories/AgentApiFactory.cs
@@ -92,7 +92,12 @@ namespace SymphonyOSS.RestApiClient.Factories
         {
             var configuration = new Configuration();
             configuration.BasePath = _baseUrl;
-            configuration.ApiClient.RestClient.HttpClientFactory = new Internal.ClientAuthHttpClientFactory(sessionManager.Certificate);
+
+            if (sessionManager.Certificate != null)
+            {
+                configuration.ApiClient.RestClient.HttpClientFactory =
+                    new Internal.ClientAuthHttpClientFactory(sessionManager.Certificate);
+            }
 
             if (apiExecutor == null)
             {


### PR DESCRIPTION
the Agent API no longer requires a client side certificate, so only add one if specified.