### PR TITLE
SYM-126 : Passing stream type to bot services

### DIFF
--- a/src/SymphonyOSS.RestApiClient/Factories/MessageFactory.cs
+++ b/src/SymphonyOSS.RestApiClient/Factories/MessageFactory.cs
@@ -49,7 +49,7 @@ namespace SymphonyOSS.RestApiClient.Factories
         {
             var attachments = v4Message.Attachments?.Select(x => new Attachment(x.Id, x.Name, x.Size)).ToList();
 
-            return new Message(v4Message.MessageId, Epoch.AddMilliseconds(v4Message.Timestamp.Value), "type", v4Message.Stream.StreamId, v4Message.Message, v4Message.User.UserId.Value, attachments, v4Message.Data);
+            return new Message(v4Message.MessageId, Epoch.AddMilliseconds(v4Message.Timestamp.Value), v4Message.Stream.StreamType.ToString(), v4Message.Stream.StreamId, v4Message.Message, v4Message.User.UserId.Value, attachments, v4Message.Data);
         }
     }
 }


### PR DESCRIPTION
Instead of the hard coded value "type" that we are passing to the bot services, we should now pass in the actual stream type that we get from Symphony.