### PR TITLE
Added a null check for the messages we receive from Symphony in Proce…

### DIFF
--- a/src/SymphonyOSS.RestApiClient/Api/AgentApi/AbstractDatafeedApi.cs
+++ b/src/SymphonyOSS.RestApiClient/Api/AgentApi/AbstractDatafeedApi.cs
@@ -193,7 +193,7 @@ namespace SymphonyOSS.RestApiClient.Api.AgentApi
 
             foreach (var message in messageList)
             {
-                switch(message.Type)
+                switch(message?.Type)
                 {
                     case V4EventType.MESSAGESENT:
                         FireMessage(message.Payload.MessageSent.Message);

--- a/src/SymphonyOSS.RestApiClient/Api/AgentApi/AbstractDatafeedApi.cs
+++ b/src/SymphonyOSS.RestApiClient/Api/AgentApi/AbstractDatafeedApi.cs
@@ -193,7 +193,12 @@ namespace SymphonyOSS.RestApiClient.Api.AgentApi
 
             foreach (var message in messageList)
             {
-                switch(message?.Type)
+                if (message == null)
+                {
+                    continue;
+                }
+
+                switch(message.Type)
                 {
                     case V4EventType.MESSAGESENT:
                         FireMessage(message.Payload.MessageSent.Message);


### PR DESCRIPTION
Added a null check for the messages we receive from Symphony in ProcessMessageList since it could be null. This was the case when we received a payload from Symphony when a user removes a connection with our bots.